### PR TITLE
Fix Postgres created/updated status, key normalization, reserved key, and frontend CSRF

### DIFF
--- a/pkg/frontend/csrf.go
+++ b/pkg/frontend/csrf.go
@@ -1,0 +1,28 @@
+package frontend
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// sameOrigin rejects requests whose Origin header (or, failing that,
+// Referer) doesn't match the request's own Host. This server has no
+// auth of its own -- it signs whatever it's told with a held key -- so
+// without this check, a form or fetch() triggered from any other page
+// loaded on the same network could add or remove links on the caller's
+// behalf. Browsers set Origin on cross-origin requests and don't let
+// page script override it, so a forged request can't fake a match.
+func sameOrigin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		src := r.Header.Get("Origin")
+		if src == "" {
+			src = r.Header.Get("Referer")
+		}
+		u, err := url.Parse(src)
+		if src == "" || err != nil || u.Host != r.Host {
+			http.Error(w, "cross-origin request rejected", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/frontend/server.go
+++ b/pkg/frontend/server.go
@@ -70,8 +70,9 @@ type server struct {
 
 func (s *server) routes() {
 	s.Handle("/static/*", http.FileServer(http.FS(static)))
-	s.Delete("/rm/{link}", s.removeLink())
-	s.HandleFunc("/", s.addLink())
+	s.With(sameOrigin).Delete("/rm/{link}", s.removeLink())
+	s.Get("/", s.addLink())
+	s.With(sameOrigin).Post("/", s.addLink())
 }
 
 func (s *server) addLink() http.HandlerFunc {

--- a/pkg/frontend/server_test.go
+++ b/pkg/frontend/server_test.go
@@ -1,0 +1,129 @@
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"jdtw.dev/links/pkg/client"
+	"jdtw.dev/links/pkg/links"
+	"jdtw.dev/links/pkg/tokentest"
+)
+
+// newTestServer wires a real links backend to a frontend handler, the same
+// way cmd/client does, so CSRF checks can be exercised end to end.
+func newTestServer(t *testing.T) http.Handler {
+	t.Helper()
+	keyset, priv := tokentest.GenerateKey(t, "test")
+	backend := httptest.NewServer(links.NewHandler(links.NewMemStore(), keyset, 0))
+	t.Cleanup(backend.Close)
+	return NewHandler(client.New(backend.URL, priv))
+}
+
+func postForm(link, uri string) (*http.Request, *httptest.ResponseRecorder) {
+	form := url.Values{"link": {link}, "uri": {uri}}
+	req := httptest.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return req, httptest.NewRecorder()
+}
+
+func TestAddLinkRejectsCrossOrigin(t *testing.T) {
+	srv := newTestServer(t)
+
+	tests := []struct {
+		name    string
+		origin  string
+		referer string
+	}{
+		{name: "missing Origin and Referer"},
+		{name: "mismatched Origin", origin: "http://evil.example"},
+		{name: "mismatched Referer", referer: "http://evil.example/attack"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req, rr := postForm("foo", "http://example.com")
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			if tc.referer != "" {
+				req.Header.Set("Referer", tc.referer)
+			}
+			srv.ServeHTTP(rr, req)
+			if sc := rr.Result().StatusCode; sc != http.StatusForbidden {
+				t.Errorf("got status %d, want %d", sc, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+func TestAddLinkAllowsSameOrigin(t *testing.T) {
+	srv := newTestServer(t)
+
+	req, rr := postForm("foo", "http://example.com")
+	req.Header.Set("Origin", "http://example.com")
+	srv.ServeHTTP(rr, req)
+	if sc := rr.Result().StatusCode; sc != http.StatusOK {
+		t.Fatalf("Origin match: got status %d, want %d", sc, http.StatusOK)
+	}
+
+	// Referer fallback works too, when Origin is absent.
+	req, rr = postForm("bar", "http://example.com")
+	req.Header.Set("Referer", "http://example.com/")
+	srv.ServeHTTP(rr, req)
+	if sc := rr.Result().StatusCode; sc != http.StatusOK {
+		t.Fatalf("Referer fallback: got status %d, want %d", sc, http.StatusOK)
+	}
+}
+
+func TestGetIndexIsUnaffectedByCSRFCheck(t *testing.T) {
+	srv := newTestServer(t)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if sc := rr.Result().StatusCode; sc != http.StatusOK {
+		t.Fatalf("got status %d, want %d", sc, http.StatusOK)
+	}
+}
+
+func TestRemoveLinkRejectsCrossOrigin(t *testing.T) {
+	srv := newTestServer(t)
+
+	// Add the link with a valid same-origin request first.
+	req, rr := postForm("foo", "http://example.com")
+	req.Header.Set("Origin", "http://example.com")
+	srv.ServeHTTP(rr, req)
+	if sc := rr.Result().StatusCode; sc != http.StatusOK {
+		t.Fatalf("setup PUT: got status %d, want %d", sc, http.StatusOK)
+	}
+
+	req = httptest.NewRequest("DELETE", "/rm/foo", nil)
+	req.Header.Set("Origin", "http://evil.example")
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if sc := rr.Result().StatusCode; sc != http.StatusForbidden {
+		t.Fatalf("got status %d, want %d", sc, http.StatusForbidden)
+	}
+}
+
+func TestRemoveLinkAllowsSameOrigin(t *testing.T) {
+	srv := newTestServer(t)
+
+	req, rr := postForm("foo", "http://example.com")
+	req.Header.Set("Origin", "http://example.com")
+	srv.ServeHTTP(rr, req)
+	if sc := rr.Result().StatusCode; sc != http.StatusOK {
+		t.Fatalf("setup PUT: got status %d, want %d", sc, http.StatusOK)
+	}
+
+	req = httptest.NewRequest("DELETE", "/rm/foo", nil)
+	req.Header.Set("Origin", "http://example.com")
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if sc := rr.Result().StatusCode; sc != http.StatusOK {
+		t.Fatalf("got status %d, want %d", sc, http.StatusOK)
+	}
+}

--- a/pkg/links/api.go
+++ b/pkg/links/api.go
@@ -61,6 +61,10 @@ func (s *server) put() http.HandlerFunc {
 		rid := middleware.GetReqID(r.Context())
 
 		l := normalizeKey(chi.URLParam(r, "link"))
+		if l == qrKey {
+			badRequest(w, "%q is a reserved link name", qrKey)
+			return
+		}
 		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			internalError(w, err, rid)

--- a/pkg/links/api.go
+++ b/pkg/links/api.go
@@ -36,7 +36,7 @@ func (s *server) get() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		rid := middleware.GetReqID(r.Context())
 
-		l := chi.URLParam(r, "link")
+		l := normalizeKey(chi.URLParam(r, "link"))
 		lepb, err := s.store.Get(r.Context(), l)
 		if err != nil {
 			internalError(w, err, rid)
@@ -60,7 +60,7 @@ func (s *server) put() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		rid := middleware.GetReqID(r.Context())
 
-		l := chi.URLParam(r, "link")
+		l := normalizeKey(chi.URLParam(r, "link"))
 		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			internalError(w, err, rid)
@@ -108,7 +108,7 @@ func (s *server) delete() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		rid := middleware.GetReqID(r.Context())
 
-		l := chi.URLParam(r, "link")
+		l := normalizeKey(chi.URLParam(r, "link"))
 		s.store.Delete(r.Context(), l)
 		w.WriteHeader(http.StatusNoContent)
 		log.Printf("[%s] %s deleted %q", rid, subject(r.Context()), l)

--- a/pkg/links/api_test.go
+++ b/pkg/links/api_test.go
@@ -224,6 +224,39 @@ func TestCRUD(t *testing.T) {
 	}()
 }
 
+func TestPutRejectsReservedQRKey(t *testing.T) {
+	keyset, priv := tokentest.GenerateKey(t, "test")
+	srv := NewHandler(NewMemStore(), keyset, 0)
+	serveHTTP := func(method, path string, body io.Reader) *http.Response {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(method, path, body)
+		signRequest(t, priv, req)
+		srv.ServeHTTP(rr, req)
+		return rr.Result()
+	}
+
+	tests := []string{"qr", "q-r"}
+	for _, key := range tests {
+		res := serveHTTP("PUT", "/api/links/"+key, marshalLink(t, "http://example.com"))
+		if sc := res.StatusCode; sc != http.StatusBadRequest {
+			t.Errorf("PUT /api/links/%s returned %d, want %d", key, sc, http.StatusBadRequest)
+		}
+	}
+
+	// QR-code generation for an existing link is unaffected.
+	serveHTTP("PUT", "/api/links/foo", marshalLink(t, "http://example.com"))
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/qr/foo", nil)
+	srv.ServeHTTP(rr, req)
+	res := rr.Result()
+	if sc := res.StatusCode; sc != http.StatusOK {
+		t.Fatalf("GET /qr/foo returned %d, want %d", sc, http.StatusOK)
+	}
+	if ct := res.Header.Get("Content-Type"); ct != "image/png" {
+		t.Errorf("GET /qr/foo returned Content-Type %q, want image/png", ct)
+	}
+}
+
 func TestPutNormalizesHyphenatedKeys(t *testing.T) {
 	keyset, priv := tokentest.GenerateKey(t, "test")
 	srv := NewHandler(NewMemStore(), keyset, 0)

--- a/pkg/links/api_test.go
+++ b/pkg/links/api_test.go
@@ -224,6 +224,53 @@ func TestCRUD(t *testing.T) {
 	}()
 }
 
+func TestPutNormalizesHyphenatedKeys(t *testing.T) {
+	keyset, priv := tokentest.GenerateKey(t, "test")
+	srv := NewHandler(NewMemStore(), keyset, 0)
+	serveHTTP := func(method, path string, body io.Reader) *http.Response {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(method, path, body)
+		signRequest(t, priv, req)
+		srv.ServeHTTP(rr, req)
+		return rr.Result()
+	}
+
+	uri := "http://example.com"
+	res := serveHTTP("PUT", "/api/links/fo-o", marshalLink(t, uri))
+	if sc := res.StatusCode; sc != http.StatusCreated {
+		t.Fatalf("PUT /api/links/fo-o returned %d, want %d", sc, http.StatusCreated)
+	}
+
+	// The link must be stored, and thus retrievable, under its normalized key...
+	res = serveHTTP("GET", "/api/links/foo", nil)
+	if sc := res.StatusCode; sc != http.StatusOK {
+		t.Fatalf("GET /api/links/foo returned %d, want %d", sc, http.StatusOK)
+	}
+	l := new(pb.Link)
+	unmarshal(t, res.Body, l)
+	if l.Uri != uri {
+		t.Errorf("GET /api/links/foo returned %v, want %q", l, uri)
+	}
+
+	// ... which also makes it reachable via the redirect handler.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/f-oo", nil)
+	srv.ServeHTTP(rr, req)
+	if sc := rr.Result().StatusCode; sc != http.StatusFound {
+		t.Fatalf("GET /f-oo returned %d, want %d", sc, http.StatusFound)
+	}
+
+	// Deleting via a differently-hyphenated key removes the same entry.
+	res = serveHTTP("DELETE", "/api/links/f-o-o", nil)
+	if sc := res.StatusCode; sc != http.StatusNoContent {
+		t.Fatalf("DELETE /api/links/f-o-o returned %d, want %d", sc, http.StatusNoContent)
+	}
+	res = serveHTTP("GET", "/api/links/foo", nil)
+	if sc := res.StatusCode; sc != http.StatusNotFound {
+		t.Fatalf("GET /api/links/foo returned %d, want %d", sc, http.StatusNotFound)
+	}
+}
+
 func marshalLink(t *testing.T, uri string) io.Reader {
 	t.Helper()
 	l := &pb.Link{

--- a/pkg/links/postgres.go
+++ b/pkg/links/postgres.go
@@ -13,7 +13,8 @@ import (
 const (
 	get = "select link, segments from links where path=$1"
 	put = `insert into links (path, link, segments) values ($1, $2, $3)
-         on conflict (path) do update set link=excluded.link, segments=excluded.segments`
+         on conflict (path) do update set link=excluded.link, segments=excluded.segments
+         returning (xmax = 0) as inserted`
 	del  = "delete from links where path=$1"
 	list = "select * from links"
 )
@@ -63,10 +64,9 @@ func (s *PostgresStore) Get(ctx context.Context, key string) (*pb.LinkEntry, err
 }
 
 func (s *PostgresStore) Put(ctx context.Context, key string, l *pb.Link) (bool, error) {
-	_, err := s.db.Exec(ctx, put, key, l.Uri, requiredPaths(l))
-	// Always returns true, since there's no easy way to differentiate
-	// created (true) vs updated.
-	return true, err
+	var created bool
+	err := s.db.QueryRow(ctx, put, key, l.Uri, requiredPaths(l)).Scan(&created)
+	return created, err
 }
 
 func (s *PostgresStore) Delete(ctx context.Context, key string) error {

--- a/pkg/links/redirect.go
+++ b/pkg/links/redirect.go
@@ -14,6 +14,13 @@ import (
 // in the database as the "index" key.
 const Index = ".index"
 
+// normalizeKey strips hyphens from a link key, so that e.g. "my-link" and
+// "mylink" are treated as the same link. Hyphens are purely a readability
+// aid when typing a URL.
+func normalizeKey(k string) string {
+	return strings.ReplaceAll(k, "-", "")
+}
+
 func (s *server) redirect() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		rid := middleware.GetReqID(r.Context())
@@ -39,7 +46,7 @@ func (s *server) redirect() http.HandlerFunc {
 		}
 
 		// Look up the key, and unmarshal the LinkEntry from the DB
-		key = strings.ReplaceAll(key, "-", "")
+		key = normalizeKey(key)
 		le, err := s.store.Get(r.Context(), key)
 		if err != nil {
 			internalError(w, err, rid)

--- a/pkg/links/redirect.go
+++ b/pkg/links/redirect.go
@@ -14,6 +14,11 @@ import (
 // in the database as the "index" key.
 const Index = ".index"
 
+// qrKey is a reserved link key: a request whose first path segment is
+// qrKey renders a QR code instead of redirecting. A link stored under
+// this key would never be reachable, so put() rejects it.
+const qrKey = "qr"
+
 // normalizeKey strips hyphens from a link key, so that e.g. "my-link" and
 // "mylink" are treated as the same link. Hyphens are purely a readability
 // aid when typing a URL.
@@ -36,7 +41,7 @@ func (s *server) redirect() http.HandlerFunc {
 		}
 
 		// If prefixed with the /qr/ path, show a QR instead of redirecting.
-		qr := key == "qr"
+		qr := key == qrKey
 		if qr {
 			if len(paths) == 0 {
 				key = Index


### PR DESCRIPTION
## Summary
- Fix `PostgresStore.Put` to correctly report created vs. updated (it always returned `true`, so the API always responded 201 instead of 204 on update, contradicting the documented contract) — the `MemStore`-backed tests never caught this since only `MemStore` got it right.
- Normalize hyphens out of link keys at write time (`PUT`/`GET`/`DELETE`), not just at redirect time — previously a link stored with a hyphen in its name (e.g. `fo-o`) was permanently unreachable via redirect, since incoming request paths are always de-hyphenated before lookup.
- Reject the reserved `qr` link name in `PUT` — `redirect()` treats a first path segment of `qr` as a QR-code mode switch, so a link literally named `qr` was storable but never reachable.
- Reject cross-origin requests to the frontend's `POST /` and `DELETE /rm/{link}` routes via an Origin/Referer check — the frontend has no auth of its own (it signs whatever it's told with a held key), so any page loaded on the same network could previously forge an add/remove.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Verified the Postgres fix against a real local Postgres instance (`dev/docker-compose.yml`): `created=true` on insert, `created=false` on update
- [x] New tests: `TestPutNormalizesHyphenatedKeys`, `TestPutRejectsReservedQRKey`, and frontend CSRF tests exercising a real end-to-end frontend→backend round trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)