### PR TITLE
Bump jdtw.dev/token to v0.1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	google.golang.org/protobuf v1.36.10
-	jdtw.dev/token v0.1.5
+	jdtw.dev/token v0.1.6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -223,5 +223,5 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-jdtw.dev/token v0.1.5 h1:AjHaR0SvzieEHgJibttay29nFG2aZn4rfj72SPf5/lk=
-jdtw.dev/token v0.1.5/go.mod h1:JDLgs93I+O0JFT4FjP9HOTvPZoTPDxCDu5WU/fzJTF8=
+jdtw.dev/token v0.1.6 h1:EzvBOo0s+O4cudJqZob1ynhyIjtWfS85Oxfk/b0iqP4=
+jdtw.dev/token v0.1.6/go.mod h1:qr+zsFbOixxkv7T5Jb7rar/5Gs2yhw27vyNX0Q7pBA4=


### PR DESCRIPTION
## Summary
Bumps `jdtw.dev/token` v0.1.5 → v0.1.6, picking up two fixes from [jdtw/token#3](https://github.com/jdtw/token/pull/3):
- `serverResource` no longer double-unescapes the request path. It could reject legitimately-signed requests whose path contains a literal `%` followed by hex digits, and more importantly broke the invariant that the resource a client signs matches the resource the server checks.
- `MapVerifier.pruned` now advances correctly, so nonce pruning is scheduled once per window instead of spawning a new goroutine on every single `Verify` call once the first window has elapsed -- this is the nonce verifier `links` actually uses ([pkg/links/server.go](https://github.com/jdtw/links/blob/main/pkg/links/server.go)).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `./docker_test.sh` -- full integration suite against a real Postgres instance, exercising the actual sign/verify and nonce-checking path

🤖 Generated with [Claude Code](https://claude.com/claude-code)