### PR TITLE
Declare the SQLite volume mount in fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -4,7 +4,7 @@
 #
 
 app = "jdtw"
-primary_region = "sea"
+primary_region = "sjc"
 kill_signal = "SIGINT"
 kill_timeout = "5s"
 
@@ -13,6 +13,13 @@ kill_timeout = "5s"
 
 [env]
   SKEW = "5s"
+
+# Backing store for the SQLite database named by the SQLITE_PATH secret.
+# The volume lives in sjc, matching the machine; a volume in another region
+# cannot attach.
+[[mounts]]
+  source = "links_data"
+  destination = "/data"
 
 [[services]]
   protocol = "tcp"


### PR DESCRIPTION
## Why

`SQLITE_PATH` is set on the app and points into `/data`. That directory exists only because a volume is mounted there — and that mount was applied by hand during the migration rather than through config.

So a `fly deploy` from a clean checkout would produce a machine with no `/data`, fail to open the database, and exit. With the Postgres cluster now gone there is nothing to fall back to, which makes that a full outage rather than a degraded start.

## What

- Declare the `links_data` mount at `/data`.
- Correct `primary_region`, which said `sea` while the machine and its volume are both in `sjc`. Volumes cannot attach across regions, so the stale value is the same trap in a different form: it would place a machine where no volume exists.

This matches the state the app is actually running in today — it's config catching up to reality, not a behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)