### PR TITLE
Fix a race in TestClient

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,51 +1,28 @@
 package client
 
 import (
-	"context"
 	"errors"
-	"fmt"
-	"net"
-	"net/http"
-	"sync"
+	"net/http/httptest"
 	"testing"
 
 	"jdtw.dev/links/pkg/links"
 	"jdtw.dev/links/pkg/tokentest"
 )
 
-func getFreePort(t *testing.T) int {
-	t.Helper()
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("net.ResolveTCPAddr failed: %v", err)
-	}
-
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		t.Fatalf("net.ListenTCP failed: %v", err)
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port
-}
-
 func TestClient(t *testing.T) {
 	ks, signer := tokentest.GenerateKey(t, "test")
 	store := links.NewMemStore()
-	var wg sync.WaitGroup
-	wg.Add(1)
-	addr := fmt.Sprintf("localhost:%d", getFreePort(t))
-	s := &http.Server{Addr: addr, Handler: links.NewHandler(store, ks, 0)}
-	go func() {
-		defer wg.Done()
-		s.ListenAndServe()
-	}()
-	ctx := context.Background()
-	t.Cleanup(func() {
-		s.Shutdown(ctx)
-		wg.Wait()
-	})
 
-	c := New("http://"+addr, signer)
+	// httptest.NewServer binds before it returns, so the client below cannot
+	// race the listener. The previous version picked a port, closed it, then
+	// started the server in a goroutine and immediately dialed -- which meant
+	// the request could arrive before the server was listening (and left a
+	// window for another process to take the port). That raced on loaded CI
+	// runners.
+	s := httptest.NewServer(links.NewHandler(store, ks, 0))
+	t.Cleanup(s.Close)
+
+	c := New(s.URL, signer)
 	if _, err := c.Get("foo"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("Get(foo) returned %v; want err %v", err, ErrNotFound)
 	}


### PR DESCRIPTION
## What happened

CI failed on the merge of #30. That PR added only four files under `frontend/` — no Go, no `go.mod`, no workflow changes — so it didn't cause this. `TestClient` has been racy all along and happened to lose on that run.

```
client_test.go:50: Get(foo) returned Get "http://localhost:46697/api/links/foo":
    dial tcp [::1]:46697: connect: connection refused; want err not found
```

## The race

```go
addr := fmt.Sprintf("localhost:%d", getFreePort(t))   // binds, then CLOSES
s := &http.Server{Addr: addr, ...}
go func() { s.ListenAndServe() }()                     // binds asynchronously
c := New("http://"+addr, signer)
c.Get("foo")                                           // dials immediately
```

Nothing orders the bind before the first request. On an idle machine the goroutine wins; on a loaded CI runner it doesn't. There's a second, narrower race too: closing the listener before rebinding leaves a window for another process to take the port.

The `[::1]` in the error is a symptom of the same design — `localhost` was reassembled from a port number rather than using the address actually bound, so the client could resolve to a different stack than the server used.

## The fix

`httptest.NewServer` binds before it returns and hands back the address it actually bound. That closes both races and the IPv4/IPv6 mismatch at once, and drops `getFreePort`, the `sync.WaitGroup`, and the manual `Shutdown`. `pkg/frontend/server_test.go` already tests this way, so this makes the two consistent.

## Verification

I could not reproduce the failure locally — expected for a scheduling race on an idle machine. I tried `-count=500`, `GOMAXPROCS=1`, and saturating every core; it passed throughout, which is why the fix is reasoned from the code rather than from a red test.

After the change: 500 runs, 50 runs under `-race`, 300 under `GOMAXPROCS=1`, the full unit suite, and the end-to-end `./test.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)